### PR TITLE
ASCN-230:  Ingress/Cert fixes for GKE

### DIFF
--- a/cnab/app/run.ps1
+++ b/cnab/app/run.ps1
@@ -154,7 +154,7 @@ switch ($action) {
       }
 
       ingress                 = @{
-        className  = "nginx-external"
+        className  = "nginx-internal"
         certIssuer = "letsencrypt-dns-prod"
         host       = $vars.vars.opserverSettings.hostUrl
         enabled    = $vars.vars.includeIngress

--- a/cnab/app/run.ps1
+++ b/cnab/app/run.ps1
@@ -47,8 +47,8 @@ $releaseTag = $vars.pipeline.releaseTag
 # PR container images are located in `cr-dev` in CloudSmith. As opposed to `cr` which we use for release builds.
 $isPr = $releaseTag -match '^pr-[0-9]+$'
 if ($isPr) {
-  $containerRegistryUrl = 'crdev.stackoverflow.software'
-  $pullSecretName = 'cloudsmith-cr-dev'
+  $containerRegistryUrl = 'cr.stackoverflow.software'
+  $pullSecretName = 'cloudsmith-cr-prod'
   $forceUpgrade = @('--force') # This'll force pods to be recreated with freshly-pulled images
 }
 else {

--- a/cnab/app/run.ps1
+++ b/cnab/app/run.ps1
@@ -159,6 +159,7 @@ switch ($action) {
         host       = $vars.vars.opserverSettings.hostUrl
         enabled    = $vars.vars.includeIngress
         secretName = "opserver-tls"
+        createTlsCert = $true
       }
 
       sqlExternalSecret       = @{


### PR DESCRIPTION
The app was inappropriately hosted on http with the ssl not working.  Turns out it was set to external ingress.  This updates to internal ingress.

Related:  the value to generate TLS certs defaults to `false` in `values.yaml` but we need to always have it be `true` in GCP since internal apps need it.

Unrelated but was breaking the build:  The app has been set to always use `cr` and not `cr-dev` but one area in the CNAB script was overlooked.  This fixes that.