### PR TITLE
WIP:  Seeing if/how we can prevent prs from going to prod

### DIFF
--- a/.github/actions/build_docker/action.yml
+++ b/.github/actions/build_docker/action.yml
@@ -39,7 +39,7 @@ runs:
         images: ${{ inputs.image_name }}
         # https://github.com/docker/metadata-action/tree/master?tab=readme-ov-file#priority-attribute
         # The default priority of sha is 100, and for custom/raw tags is 200. The highest the most priority.
-        # We want the sha tag to be the one used for the OCI label and the version output, so we set the priority of the custom date tag to the lowest.
+        # We want the sha tag to be the one used for the OCI label and the version output, so we set the priority of the custom date tag to lower, followed by the PR number tag.
         tags: |
           type=sha,priority=100
           ${{ inputs.version }},priority=1


### PR DESCRIPTION
Opsever uses a single registry.  This PR is where I experiment with ways to prevent a pr image from going to prod.