### PR TITLE
ASCN-297:  Reduce/eliminate chatty log messages that we don't need

### DIFF
--- a/charts/opserver/templates/deployment.yaml
+++ b/charts/opserver/templates/deployment.yaml
@@ -63,7 +63,8 @@ spec:
 
         - name: DOTNET_EnableDiagnostics
           value: "0"
-
+        - name: Logging__LogLevel__Microsoft
+          value: "Warning"
         - name: ASPNETCORE_ENVIRONMENT
           value: {{ .Values.aspnetcoreEnvironment }}
         - name: PRODUCT


### PR DESCRIPTION
We are currently logging every request start/stop in opserver when it's in a container.  We don't need that information in our logs and it will increase our datadog costs if we keep it there.

This updates the loglevel for microsoft events to Warning to match what we do in other apps.

<img width="1116" alt="image" src="https://github.com/user-attachments/assets/f1fd5da6-133d-441d-acf8-63bd9c8dbeea">
