### PR TITLE
[ASCN-340] Update date_version GHA to latest version 

### DIFF
--- a/.github/actions/date_version/action.yml
+++ b/.github/actions/date_version/action.yml
@@ -8,20 +8,25 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Generate Version
-      id: generate-version
-      shell: pwsh
-      run: |
-        # modulo the build number to ensure we don't overflow the max patch value allowed by nuget
-        $buildNumber = $env:GITHUB_RUN_NUMBER%65535
-        $version = "$(Get-Date -Format "yyyy.M.d").$buildNumber"
+  - name: Generate Version
+    id: generate-version
+    shell: bash
+    run: |
+      set -euo pipefail
+      github_run_number=${{ github.run_number }}
+      github_ref=${{ github.ref }}
+      build_number=$(($github_run_number % 65535))
 
-        # add the -pr suffix when this is running on a PR branch
-        $github_ref = "${{ github.ref }}"
-        if ($github_ref.StartsWith("refs/pull"))
-        {
-          $version = "${version}-pr"
-        }
+      date=$(date +%Y.%-m.%-d)
 
-        echo "version=$version" >> $env:GITHUB_OUTPUT
-        echo "generated version: $version"
+      version="${date}.${build_number}"
+      is_pr=0
+      echo $github_ref | grep "^refs\/pull\/" && is_pr=1
+
+      if [ $is_pr -eq 1 ]
+      then
+        version="${version}-pr"
+      fi
+
+      echo "Version: $version"
+      echo "version=$version" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR is for [ASCN-340](https://stackoverflow.atlassian.net/browse/ASCN-340).

There is a new version of our internal date_version task that switches from using PowerShell to Bash and gives us a free performance improvement of on average 12 seconds.

Since OpServer is a fork, it can't use our internal GitHub tasks. I've copied the new version into the repo to replace the old one.

[ASCN-340]: https://stackoverflow.atlassian.net/browse/ASCN-340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ