### PR TITLE
ASCN-352:  Update local cnab experience

### DIFF
--- a/.github/workflows/workflow_build_and_release_containers.yaml
+++ b/.github/workflows/workflow_build_and_release_containers.yaml
@@ -74,7 +74,7 @@ jobs:
         run: |
           octoSpaceId="Spaces-1"
           octoProjectId="Projects-2241"
-          environmentId="${{ github.ref_name == 'main' && 'Dev' || 'Sandbox' }}"
+          environmentId="${{ github.ref_name == 'main' && 'main-test' || 'ascn-dev' }}"
 
           dotnet octo deploy-release --project=$octoProjectId --space=$octoSpaceId --version=${{ needs.generate_date_version.outputs.version }} \
           --server=${{ vars.OCTOPUS_CLOUD_URL }} --apiKey=${{ secrets.OCTOPUS_CLOUD_API_KEY }} --deployTo=$environmentId

--- a/.github/workflows/workflow_build_and_release_containers.yaml
+++ b/.github/workflows/workflow_build_and_release_containers.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: determine if we should create release and deploy
         id: should-create-release
         run: |
-          if [[ ${{ github.ref_name == 'main' || github.pull_request.labels.*.name == 'deploy-to-sandbox' }} ]]; then
+          if [[ ${{ github.ref_name == 'main' || github.pull_request.labels.*.name == 'deploy-to-ascn-dev' }} ]]; then
             echo "SHOULD_CREATE_RELEASE=true" >> $GITHUB_ENV
           else
             echo "SHOULD_CREATE_RELEASE=false" >> $GITHUB_ENV

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# These get copied locally when running Invoke-CNAB not in a container
+cnab/app/container-registry-discovery.ps1
+cnab/app/gcp-cluster-discovery.ps1
+cnab/app/run.ps1
+cnab/app/utils.ps1
+
 #################
 ## Visual Studio
 #################

--- a/cnab/app/build-app-image.ps1
+++ b/cnab/app/build-app-image.ps1
@@ -1,0 +1,5 @@
+function Build-Local-App-Image() {
+
+      
+    docker build -t local.software/stackeng/opserver/opserver -t cr.stackoverflow.software/stackeng/opserver/opserver:local .
+}

--- a/cnab/app/variables.DockerDesktop.json
+++ b/cnab/app/variables.DockerDesktop.json
@@ -11,7 +11,7 @@
     "name": "DockerDesktop"
   },
   "vars": {
-    "secretStore": "cluster-secrets",
+    "secretStore": "fakeopserversecretstore",
     "imagePullPolicy": "IfNotPresent",
     "replicaCount": "1",
     "aspnetcoreEnvironment": "Local",

--- a/cnab/app/variables.DockerDesktop.json
+++ b/cnab/app/variables.DockerDesktop.json
@@ -3,18 +3,12 @@
     "environment": "local",
     "product": "pubplat",
     "project": "opserver",
-    "tenant": "local",
     "releaseTag": "local"
   },
   "runtime": {
     "cd": false,
     "local": true,
     "name": "DockerDesktop"
-  },
-  "tenant_metadata": {
-    "gke_cluster_name": "",
-    "region": "",
-    "project": ""
   },
   "vars": {
     "secretStore": "cluster-secrets",

--- a/cnab/app/variables.GCP.json
+++ b/cnab/app/variables.GCP.json
@@ -3,7 +3,7 @@
     "environment": "dev",
     "product": "pubplat",
     "project": "opserver",
-    "releaseTag": "pr-10"
+    "releaseTag": "pr-12"
   },
   "runtime": {
     "cd": false,

--- a/cnab/app/variables.GCP.json
+++ b/cnab/app/variables.GCP.json
@@ -31,7 +31,7 @@
     "isHADRPrimary": "true",
     "podDisruptionBudgetMinAvailable": "1",
     "opserverSettings": {
-      "hostUrl": "opserver.sandbox.int.gcp.stackoverflow.net",
+      "hostUrl": "opserver.ascn-dev.int.gcp.stackoverflow.net",
       "sql": [
         { "name": "db.db" }
       ],

--- a/cnab/app/variables.GCP.json
+++ b/cnab/app/variables.GCP.json
@@ -3,7 +3,6 @@
     "environment": "dev",
     "product": "pubplat",
     "project": "opserver",
-    "tenant": "sandbox",
     "releaseTag": "pr-10"
   },
   "runtime": {
@@ -11,11 +10,6 @@
     "local": false,
     "name": "GCP"
   },
-  "tenant_metadata": {
-    "gke_cluster_name": "",
-    "region": "",
-    "project": ""
-  },  
   "deploymentDiscovery": {
     "deploymentGroupFilter": "labels.env=dev AND labels.project=base AND labels.product=pubplat AND labels.instance=ascn-dev",
     "deploymentTargetFilter": "resourceLabels.deployment_target=true"

--- a/cnab/build/Dockerfile
+++ b/cnab/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM cr.stackoverflow.software/so-pubplat-cnab:2024.9.25.214002-238.1@sha256:bd33fc10fb6f59e328d7210a6fa48cae470f5d25ce6da115f6c877e42f9204f3
+FROM cr.stackoverflow.software/so-pubplat-cnab:2024.10.16.174409-276.1@sha256:36cf26cd2d2ea251ce46edcc966174ab1ed95ccf2818cdc763ba58a384328177
     
 COPY ./cnab/app /cnab/app
 COPY ./charts /cnab/app/charts


### PR DESCRIPTION
This updates our local CNAB scripts to align with the other apps.

Related Octopus PR (already merged):  https://github.com/StackEng/Octopus/pull/511

# How to test
1. Run octopus deploy for this pr
2. Run various combations of `Invoke-CNAB`:
   - `.\cnab\invoke-CNAB.ps1 install $true gcp`
   - `.\cnab\invoke-CNAB.ps1 install $false gcp`
   - `.\cnab\invoke-CNAB.ps1 install $false dockerdesktop`
   - `.\cnab\invoke-CNAB.ps1 install $true dockerdesktop`
3. Review the github action auto-deploy-when-label-present result here: 
    - Github action: https://github.com/StackEng/Opserver/actions/runs/11469040145/job/31915434092?pr=12
    - Octopus deploy: https://stackeng.octopus.app/app#/Spaces-1/projects/opserver/deployments/releases/2024.10.22.88-pr/deployments/Deployments-160631