### PR TITLE
[ASCN-227] Add support for Reloader in Kubernetes 

### DIFF
--- a/charts/opserver/Chart.yaml
+++ b/charts/opserver/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.13
+version: 1.0.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opserver/templates/deployment.yaml
+++ b/charts/opserver/templates/deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/cnab/app/variables.GCP.json
+++ b/cnab/app/variables.GCP.json
@@ -3,7 +3,7 @@
     "environment": "dev",
     "product": "pubplat",
     "project": "opserver",
-    "releaseTag": "pr-12"
+    "releaseTag": "pr-13"
   },
   "runtime": {
     "cd": false,


### PR DESCRIPTION
This PR is for [ASCN-227](https://stackoverflow.atlassian.net/browse/ASCN-227) and does the exact same thing as [this Scheduler PR](https://github.com/StackEng/Scheduler/pull/326).

This PR follows [these instructions](https://github.com/StackEng/SelfServiceTemplate/blob/main/deploy/base/deployment.yaml) to add the annotation to enable Reloader to the deployment. Reloader is already installed in the Kubernetes cluster by SRE. By having this annotation, Kubernetes will make sure pods are restarted when a secret or config map changes.

## How to test

1. Deploy this PR to `ascn-dev` through local CNAB
2. Open the `ascn-dev` cluster in Lens and go to the `OpServer` namespace. There should be 1 pod that has been running for a while
3. Change the deployment replica to `3`
4. Change the external secret refresh to `1s` (so you don't have to wait 5 minutes after changing the GCP secret)
5. Edit the Okta Client Id secret in GCP [here](https://console.cloud.google.com/security/secret-manager/secret/opserver-okta-client-id/versions?project=ascn-dev-base-957a) to `my_okta_secret` 
6. Kubernetes will auto create new pods 1 by 1 until all 3 pods are replaced
7. Revert the secret change

[ASCN-227]: https://stackoverflow.atlassian.net/browse/ASCN-227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ