### PR TITLE
ASCN-357:  Fix pr tag on main builds

### DIFF
--- a/.github/actions/build_docker/action.yml
+++ b/.github/actions/build_docker/action.yml
@@ -43,7 +43,7 @@ runs:
         tags: |
           type=sha,priority=100
           ${{ inputs.version }},priority=1
-          ${{ github.ref_name == 'main' && '' || format('pr-{0}', github.event.pull_request.number) }}
+          type=ref,event=pr
         flavor: latest=false
 
     - name: Login to Docker Registry - prod


### PR DESCRIPTION
This PR is for [ASCN-357](https://stackoverflow.atlassian.net/browse/ASCN-357) and applies the same fix as https://github.com/StackEng/SocketServer/pull/17.

[ASCN-357]: https://stackoverflow.atlassian.net/browse/ASCN-357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ