### PR TITLE
[ASCN-382] Split secrets for Exceptional and Status

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Invoke-CNAB",
+            "type": "PowerShell",
+            "request": "launch",
+            "script": "${workspaceFolder}/cnab/Invoke-CNAB.ps1",
+            "args": []
+        }
+    ]
+}

--- a/charts/opserver/Chart.yaml
+++ b/charts/opserver/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.14
+version: 1.0.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opserver/templates/deployment.yaml
+++ b/charts/opserver/templates/deployment.yaml
@@ -97,23 +97,6 @@ spec:
 
         - name: TMPDIR #tell OS to use our read-write volume mount as its temp directory
           value: "/mnt/tmp"
-
-        - name: SQL_EXCEPTIONAL_SERVERNAME
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.sqlExternalSecret.targetName }}
-              key: exceptionalServername
-        - name: SQL_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.sqlExternalSecret.targetName }}
-              key: exceptionalUsername
-        - name: SQL_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.sqlExternalSecret.targetName }}
-              key: exceptionalPassword
-
         - name: Security__Provider
           value: {{ .Values.opserverSettings.security.provider }}
 
@@ -155,22 +138,57 @@ spec:
 {{- end }}
 
       {{- if hasKey .Values.opserverSettings "sql" }}      
+        - name: SQL_STATUS_SERVERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.sqlExternalSecret.targetName }}
+              key: {{ .Values.sqlExternalSecret.remoteRefs.sqlStatusSqlServerName }}
+
+        - name: SQL_STATUS_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.sqlExternalSecret.targetName }}
+              key: {{ .Values.sqlExternalSecret.remoteRefs.sqlStatusUsername }}
+        - name: SQL_STATUS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.sqlExternalSecret.targetName }}
+              key: {{ .Values.sqlExternalSecret.remoteRefs.sqlStatusPassword }}
+
         - name: Modules__Sql__defaultConnectionString
-          value: "Server=$(SQL_EXCEPTIONAL_SERVERNAME);Database=master;User ID=$(SQL_USERNAME);Password=$(SQL_PASSWORD);TrustServerCertificate=True"
+          value: "Server=$(SQL_STATUS_SERVERNAME);Database=master;User ID=$(SQL_STATUS_USERNAME);Password=$(SQL_STATUS_PASSWORD);TrustServerCertificate=True"
+
         {{- range $i, $instance := .Values.opserverSettings.sql }}
         - name: Modules__Sql__instances__{{ $i }}__name
           value: "{{ $instance.name }}"
         {{- end }}
-
-        - name: EXCEPTIONAL__STORE__CONNECTIONSTRING
-          value: Server=$(SQL_EXCEPTIONAL_SERVERNAME),1433;Database={{ .Values.db.exceptionalDbName }};Persist Security Info=False;User ID=$(SQL_USERNAME);Password=$(SQL_PASSWORD);MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=True;Connection Timeout=30;MultiSubnetFailover=True
       {{- end }}
 
       {{- if hasKey .Values.opserverSettings "exceptions" }}      
+        - name: SQL_EXCEPTIONAL_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.sqlExternalSecret.targetName }}
+              key: {{ .Values.sqlExternalSecret.remoteRefs.exceptionalUsername }}
+        - name: SQL_EXCEPTIONAL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.sqlExternalSecret.targetName }}
+              key: {{ .Values.sqlExternalSecret.remoteRefs.exceptionalPassword }}
+
         {{- range $i, $instance := .Values.opserverSettings.exceptions }}
         - name: Modules__Exceptions__stores__{{ $i }}__connectionString
-          value: "Server={{ $instance.serverName}};Database={{ $instance.database}};User ID=$(SQL_USERNAME);Password=$(SQL_PASSWORD);TrustServerCertificate=True"
+          value: "Server={{ $instance.serverName}};Database={{ $instance.database}};User ID=$(SQL_EXCEPTIONAL_USERNAME);Password=$(SQL_EXCEPTIONAL_PASSWORD);TrustServerCertificate=True"
         {{- end }}
+
+        - name: SQL_EXCEPTIONAL_SERVERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.sqlExternalSecret.targetName }}
+              key: {{ .Values.sqlExternalSecret.remoteRefs.exceptionalServerName }}
+
+        - name: EXCEPTIONAL__STORE__CONNECTIONSTRING
+        value: Server=$(SQL_EXCEPTIONAL_SERVERNAME),1433;Database={{ .Values.db.exceptionalDbName }};Persist Security Info=False;User ID=$(SQL_EXCEPTIONAL_USERNAME);Password=$(SQL_EXCEPTIONAL_PASSWORD);MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=True;Connection Timeout=30;MultiSubnetFailover=True
       {{- end }}
 
       topologySpreadConstraints:

--- a/charts/opserver/templates/fake-secretstore.yaml
+++ b/charts/opserver/templates/fake-secretstore.yaml
@@ -10,10 +10,16 @@ spec:
   provider:
     fake:
       data:
-      - key: "ExceptionsSqlServerName"
+      - key: {{ .Values.sqlExternalSecret.remoteRefs.sqlStatusSqlServerName }}
         value: "host.docker.internal"
-      - key: "db-opserver-User"
+      - key: {{ .Values.sqlExternalSecret.remoteRefs.sqlStatusUsername }}
         value: "opserver"
-      - key: "db-opserver-Password"
+      - key: {{ .Values.sqlExternalSecret.remoteRefs.sqlStatusPassword }}
+        value: "opserver"
+      - key: {{ .Values.sqlExternalSecret.remoteRefs.exceptionalServerName }}
+        value: "host.docker.internal"
+      - key: {{ .Values.sqlExternalSecret.remoteRefs.exceptionalUsername }}
+        value: "opserver"
+      - key: {{ .Values.sqlExternalSecret.remoteRefs.exceptionalPassword }}
         value: "opserver"
 {{ end }}

--- a/charts/opserver/templates/opserver-secret.yaml
+++ b/charts/opserver/templates/opserver-secret.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.opserverSettings.security.provider "OIDC" }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -16,3 +17,4 @@ spec:
   - secretKey: oktaClientSecret
     remoteRef:
       key: {{ .Values.opserverExternalSecret.remoteRefs.oktaClientSecret }}
+{{- end }}

--- a/charts/opserver/templates/sql-external-secret.yaml
+++ b/charts/opserver/templates/sql-external-secret.yaml
@@ -10,12 +10,23 @@ spec:
   target:
     name: {{ .Values.sqlExternalSecret.targetName }}
   data:
-  - secretKey: exceptionalServername
+  # These secrets are used by the Sql module of OpServer
+  - secretKey: {{ .Values.sqlExternalSecret.remoteRefs.sqlStatusSqlServerName }}
+    remoteRef:
+      key: {{ .Values.sqlExternalSecret.remoteRefs.sqlStatusSqlServerName }}
+  - secretKey: {{ .Values.sqlExternalSecret.remoteRefs.sqlStatusUsername }}
+    remoteRef:
+      key: {{ .Values.sqlExternalSecret.remoteRefs.sqlStatusUsername }}
+  - secretKey: {{ .Values.sqlExternalSecret.remoteRefs.sqlStatusPassword }}
+    remoteRef:
+      key: {{ .Values.sqlExternalSecret.remoteRefs.sqlStatusPassword }}
+  # These secrets are used for the Exceptional module of OpServer 
+  - secretKey: {{ .Values.sqlExternalSecret.remoteRefs.exceptionalServerName }}
     remoteRef:
       key: {{ .Values.sqlExternalSecret.remoteRefs.exceptionalServerName }}
-  - secretKey: exceptionalUsername
+  - secretKey: {{ .Values.sqlExternalSecret.remoteRefs.exceptionalUsername }}
     remoteRef:
       key: {{ .Values.sqlExternalSecret.remoteRefs.exceptionalUsername }}
-  - secretKey: exceptionalPassword
+  - secretKey: {{ .Values.sqlExternalSecret.remoteRefs.exceptionalPassword }}
     remoteRef:
       key: {{ .Values.sqlExternalSecret.remoteRefs.exceptionalPassword }}

--- a/charts/opserver/values.yaml
+++ b/charts/opserver/values.yaml
@@ -69,10 +69,10 @@ sqlExternalSecret:
   targetName: sql-secret
   remoteRefs:
     sqlStatusSqlServerName: SqlStatusSqlServerName
-    sqlStatusUsername: db-opserver-sql-status-User
-    sqlStatusPassword: db-opserver-sql-status-Password
+    sqlStatusUsername: db-Opserver-Sql-Status-User
+    sqlStatusPassword: db-Opserver-Sql-Status-Password
     exceptionalServerName: ExceptionsSqlServerName
-    exceptionalUsername: db-exceptions-User
-    exceptionalPassword: db-exceptions-Password
+    exceptionalUsername: db-Exceptions-User
+    exceptionalPassword: db-Exceptions-Password
 
 nodeScheduling: {}

--- a/charts/opserver/values.yaml
+++ b/charts/opserver/values.yaml
@@ -68,8 +68,11 @@ sqlExternalSecret:
   storeRefName: fakeopserversecretstore
   targetName: sql-secret
   remoteRefs:
+    sqlStatusSqlServerName: SqlStatusSqlServerName
+    sqlStatusUsername: db-opserver-sql-status-User
+    sqlStatusPassword: db-opserver-sql-status-Password
     exceptionalServerName: ExceptionsSqlServerName
-    exceptionalUsername: db-opserver-User
-    exceptionalPassword: db-opserver-Password
+    exceptionalUsername: db-exceptions-User
+    exceptionalPassword: db-exceptions-Password
 
 nodeScheduling: {}

--- a/cnab/app/build-app-image.ps1
+++ b/cnab/app/build-app-image.ps1
@@ -1,5 +1,5 @@
 function Build-Local-App-Image() {
 
       
-    docker build -t local.software/stackeng/opserver/opserver -t cr.stackoverflow.software/stackeng/opserver/opserver:local .
+    # docker build -t local.software/stackeng/opserver/opserver -t cr.stackoverflow.software/stackeng/opserver/opserver:local .
 }

--- a/cnab/app/build-app-image.ps1
+++ b/cnab/app/build-app-image.ps1
@@ -1,5 +1,3 @@
 function Build-Local-App-Image() {
-
-      
-    # docker build -t local.software/stackeng/opserver/opserver -t cr.stackoverflow.software/stackeng/opserver/opserver:local .
+     docker build -t local.software/stackeng/opserver/opserver -t cr.stackoverflow.software/stackeng/opserver/opserver:local .
 }

--- a/cnab/app/variables.DockerDesktop.json
+++ b/cnab/app/variables.DockerDesktop.json
@@ -40,6 +40,7 @@
         "viewGroups": "",
         "provider": "EveryonesAnAdmin"          
       }
+
     }
   }
 }

--- a/cnab/app/variables.DockerDesktop.json
+++ b/cnab/app/variables.DockerDesktop.json
@@ -40,7 +40,6 @@
         "viewGroups": "",
         "provider": "EveryonesAnAdmin"          
       }
-
     }
   }
 }

--- a/cnab/app/variables.GCP.json
+++ b/cnab/app/variables.GCP.json
@@ -3,7 +3,7 @@
     "environment": "dev",
     "product": "pubplat",
     "project": "opserver",
-    "releaseTag": "2024.11.4.107"
+    "releaseTag": "pr-18"
   },
   "runtime": {
     "cd": false,


### PR DESCRIPTION
This PR is for [ASCN-382](https://stackoverflow.atlassian.net/browse/ASCN-382).

DBRE uses two sets of credentials for OpServer:
- One for Exceptions (e.g. https://opserver.ascn-dev.int.gcp.stackoverflow.net/exceptions)
- One for SQL Status (e.g. https://opserver.ascn-dev.int.gcp.stackoverflow.net/sql/instance?node=db.db)

This PR adds a second set of secrets and splits the Sql secrets we use for Exceptional and Sql Status so we can configure this correctly in prod. For `ascn-dev`, I added the required secrets and deployed successfully from local CNAB.

I also asked Aaron if each app should have its own Exceptional credentials [here](https://stackexchange.slack.com/archives/C05PV8H4M6U/p1731580798978979) since I think we now share the `db-Exceptions-User` between all apps and I don't think that's correct.

[ASCN-382]: https://stackoverflow.atlassian.net/browse/ASCN-382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ