### PR TITLE
[ASCN-382] Fix formatting of EXCEPTIONAL__STORE__CONNECTIONSTRING

### DIFF
--- a/charts/opserver/Chart.yaml
+++ b/charts/opserver/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.15
+version: 1.0.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opserver/templates/deployment.yaml
+++ b/charts/opserver/templates/deployment.yaml
@@ -188,7 +188,7 @@ spec:
               key: {{ .Values.sqlExternalSecret.remoteRefs.exceptionalServerName }}
 
         - name: EXCEPTIONAL__STORE__CONNECTIONSTRING
-        value: Server=$(SQL_EXCEPTIONAL_SERVERNAME),1433;Database={{ .Values.db.exceptionalDbName }};Persist Security Info=False;User ID=$(SQL_EXCEPTIONAL_USERNAME);Password=$(SQL_EXCEPTIONAL_PASSWORD);MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=True;Connection Timeout=30;MultiSubnetFailover=True
+          value: Server=$(SQL_EXCEPTIONAL_SERVERNAME),1433;Database={{ .Values.db.exceptionalDbName }};Persist Security Info=False;User ID=$(SQL_EXCEPTIONAL_USERNAME);Password=$(SQL_EXCEPTIONAL_PASSWORD);MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=True;Connection Timeout=30;MultiSubnetFailover=True
       {{- end }}
 
       topologySpreadConstraints:

--- a/cnab/app/variables.GCP.json
+++ b/cnab/app/variables.GCP.json
@@ -3,7 +3,7 @@
     "environment": "dev",
     "product": "pubplat",
     "project": "opserver",
-    "releaseTag": "pr-18"
+    "releaseTag": "2024.11.18.120"
   },
   "runtime": {
     "cd": false,


### PR DESCRIPTION
This PR is for [ASCN-382](https://stackoverflow.atlassian.net/browse/ASCN-382).

While testing OpServer I ran the route https://opserver.main-stg.int.gcp.stackoverflow.net/error-test and the exception did not show up on https://opserver.main-stg.int.gcp.stackoverflow.net/exceptions. 

This was because the `EXCEPTIONAL__STORE__CONNECTIONSTRING` was not set correctly because of a formatting issue. This PR fixes that.

You can see that the test exceptions now do show up in `ascn-dev`: https://opserver.ascn-dev.int.gcp.stackoverflow.net/exceptions/detail?id=ebe68750-0af2-40c9-bc0f-87acd26dd795&log=opserver

[ASCN-382]: https://stackoverflow.atlassian.net/browse/ASCN-382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ