### PR TITLE
[ASCN-413] Upgrade to .NET 8

### DIFF
--- a/.github/actions/build_docker/action.yml
+++ b/.github/actions/build_docker/action.yml
@@ -54,7 +54,7 @@ runs:
         password: ${{ inputs.registry_password }}
 
     - name: Build Image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v6
       with:
         push: true
         context: .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,12 +4,12 @@ on: [push]
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: ubuntu-latest 
     steps:
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
-    - uses: actions/checkout@v1
+        dotnet-version: 8.0.x
+    - uses: actions/checkout@v4
     - name: Build with dotnet
       run: dotnet build

--- a/.github/workflows/workflow_build_and_release_containers.yaml
+++ b/.github/workflows/workflow_build_and_release_containers.yaml
@@ -63,12 +63,13 @@ jobs:
       - name: Create Octo Release if main or deploy to sandbox label present
         if: env.SHOULD_CREATE_RELEASE == 'true'
         run: |
-          octoSpaceId="Teams"
+          octoSpaceId="Default"
           octoProjectId="Opserver"
 
           dotnet octo create-release --project=$octoProjectId --space=$octoSpaceId --version=${{ needs.generate_date_version.outputs.version }} \
           --gitRef=main --server=${{ vars.OCTOPUS_CLOUD_URL }} --apiKey=${{ secrets.OCTOPUS_CLOUD_API_KEY }}
           # Note: The gitRef param is for the Octo config repo and not the git repo for the code
+          
       - name: Deploy via Octopus if main or deploy to ascn-dev if label present
         if: env.SHOULD_CREATE_RELEASE == 'true'
         run: |
@@ -78,4 +79,4 @@ jobs:
 
           dotnet octo deploy-release --project=$octoProjectId --space=$octoSpaceId --version=${{ needs.generate_date_version.outputs.version }} \
           --server=${{ vars.OCTOPUS_CLOUD_URL }} --apiKey=${{ secrets.OCTOPUS_CLOUD_API_KEY }} --deployTo=$environmentId
-          # Note: The gitRef param is for the Octo config repo and not the git repo for the code          
+          # Note: The gitRef param is for the Octo config repo and not the git repo for the code

--- a/.github/workflows/workflow_build_and_release_containers.yaml
+++ b/.github/workflows/workflow_build_and_release_containers.yaml
@@ -63,17 +63,17 @@ jobs:
       - name: Create Octo Release if main or deploy to sandbox label present
         if: env.SHOULD_CREATE_RELEASE == 'true'
         run: |
-          octoSpaceId="Spaces-1"
-          octoProjectId="Projects-2241"
+          octoSpaceId="Teams"
+          octoProjectId="Opserver"
 
           dotnet octo create-release --project=$octoProjectId --space=$octoSpaceId --version=${{ needs.generate_date_version.outputs.version }} \
           --gitRef=main --server=${{ vars.OCTOPUS_CLOUD_URL }} --apiKey=${{ secrets.OCTOPUS_CLOUD_API_KEY }}
           # Note: The gitRef param is for the Octo config repo and not the git repo for the code
-      - name: Deploy via Octopus if main or deploy to sandbox label present
+      - name: Deploy via Octopus if main or deploy to ascn-dev if label present
         if: env.SHOULD_CREATE_RELEASE == 'true'
         run: |
-          octoSpaceId="Spaces-1"
-          octoProjectId="Projects-2241"
+          octoSpaceId="Default"
+          octoProjectId="OpServer"
           environmentId="${{ github.ref_name == 'main' && 'main-test' || 'ascn-dev' }}"
 
           dotnet octo deploy-release --project=$octoProjectId --space=$octoSpaceId --version=${{ needs.generate_date_version.outputs.version }} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /app
 
 # Global
@@ -22,7 +22,7 @@ WORKDIR /app/src/Opserver.Web
 RUN dotnet publish -c Release -o publish
 
 # Build runtime image
-FROM cr.stackoverflow.software/so-aspnet:6.0-jammy-chiseled-extra AS base
+FROM cr.stackoverflow.software/so-aspnet:8.0-jammy-chiseled-extra AS base
 
 USER $APP_UID
 

--- a/cnab/app/variables.GCP.json
+++ b/cnab/app/variables.GCP.json
@@ -3,7 +3,7 @@
     "environment": "dev",
     "product": "pubplat",
     "project": "opserver",
-    "releaseTag": "2024.11.18.120"
+    "releaseTag": "pr-22"
   },
   "runtime": {
     "cd": false,

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -319,7 +319,7 @@ Exceptions from a [StackExchange.Exceptional](https://nickcraver.com/StackExchan
       "queryTimeoutMs": 2000, // (Optional - default: 30000) The query timeout before giving up on this store (when shit hits the fan...maybe a store isn't available)
       "pollIntervalSeconds": 30, // (Optional - default: 300) How often to poll this store for new/changed exceptions
       // SQL Server connection string to the Exceptional store
-      "connectionString": "Server=ny-sql01;Database=NY.Exceptions;Integrated Security=SSPI;"
+      "connectionString": "Server=ny-sql01;Database=NY.Exceptions;Integrated Security=SSPI;TrustServerCertificate=True"
     }
   ],
   /* (Optional) Replacements for Stack Trace descriptions. It's general purpose with specific uses in mind.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -197,7 +197,7 @@ The dashboard can currently monitor via SignalFx, Bosun, Orion or limited amount
     /* If using Orion, a host (for links, not API) and a connection string needs to be provided */
     //"orion": {
     //  "host": "orion.mydomain.com",
-    //  "connectionString": "Data Source=ny-orionsql01;Initial Catalog=SolarWindsOrion;Integrated Security=SSPI;Timeout=10"
+    //  "connectionString": "Data Source=ny-orionsql01;Initial Catalog=SolarWindsOrion;Integrated Security=SSPI;Timeout=10;TrustServerCertificate=True"
     //}
   },
   /* General dashboard UI settings */
@@ -494,7 +494,7 @@ Because AlwaysOn AGs can get into a state where the master does not know about t
 {
   // (Optional) The default connection string used unless specifically provided on a node
   // $ServerName$ gets replaces with the name property of the instance
-  "defaultConnectionString": "Data Source=$ServerName$;Initial Catalog=master;Integrated Security=SSPI;",
+  "defaultConnectionString": "Data Source=$ServerName$;Initial Catalog=master;Integrated Security=SSPI;TrustServerCertificate=True",
   "refreshIntervalSeconds": 30, // (Optional - default: 60) How often to poll all servers
   "clusters": [ // (Optional) Always On Availability Group Clusters
     {
@@ -510,7 +510,7 @@ Because AlwaysOn AGs can get into a state where the master does not know about t
   "instances": [ // (Optional) Standalone instances
     { // An example with all the options configured
       "name": "NY-DB05",
-      "connectionString": "Data Source=NY-DB05;Initial Catalog=bob;Integrated Security=SSPI;",
+      "connectionString": "Data Source=NY-DB05;Initial Catalog=bob;Integrated Security=SSPI;TrustServerCertificate=True",
       "refreshIntervalSeconds": 200
     },
     // Some standalone servers (default instance) using default refresh and connection strings:

--- a/docs/Docs.csproj
+++ b/docs/Docs.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.Build.NoTargets/3.2.14">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/src/Opserver.Core/Helpers/OpserverConfigException.cs
+++ b/src/Opserver.Core/Helpers/OpserverConfigException.cs
@@ -8,6 +8,6 @@ namespace Opserver.Helpers
         public OpserverConfigException() { }
         public OpserverConfigException(string message) : base(message) { }
         public OpserverConfigException(string message, Exception innerException) : base(message, innerException) { }
-        protected OpserverConfigException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+
     }
 }

--- a/src/Opserver.Core/Opserver.Core.csproj
+++ b/src/Opserver.Core/Opserver.Core.csproj
@@ -2,31 +2,35 @@
   <PropertyGroup>
     <RootNamespace>Opserver</RootNamespace>
     <AssemblyName>Opserver.Core</AssemblyName>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>embedded</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="Enums.NET" Version="4.0.0" />
+    <PackageReference Include="Dapper" Version="2.1.35" />
+    <PackageReference Include="Enums.NET" Version="5.0.0" />
     <PackageReference Include="Jil" Version="2.17.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.8" />
-    <PackageReference Include="MiniProfiler.Shared" Version="4.3.8" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Version="8.0.11" />
+    <PackageReference Include="MiniProfiler.Shared" Version="4.5.4" />
     <PackageReference Include="Sigil" Version="5.0.0" />
-    <PackageReference Include="StackExchange.Exceptional.Shared" Version="2.2.32" />
-    <PackageReference Include="StackExchange.Redis" Version="2.6.122" />
+    <PackageReference Include="StackExchange.Exceptional.Shared" Version="3.0.1" />
+    <PackageReference Include="StackExchange.Redis" Version="2.8.22" />
     <PackageReference Include="StackExchange.Utils.Http" Version="0.3.48" />
-    <PackageReference Include="System.DirectoryServices" Version="6.0.0" />
-    <PackageReference Include="System.Management" Version="6.0.0" />
-    <PackageReference Include="System.Runtime.Caching" Version="6.0.0" />
+    <PackageReference Include="System.DirectoryServices" Version="9.0.0" />
+    <PackageReference Include="System.Management" Version="9.0.0" />
+    <PackageReference Include="System.Runtime.Caching" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Data\SQL\QueryPlans\ShowPlanXML.cs" SubType="Code" />
     <Compile Update="Data\SQL\QueryPlans\ShowPlanXML.generated.cs" SubType="Code" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.7.112" />
   </ItemGroup>
 </Project>

--- a/src/Opserver.Web/Opserver.Web.csproj
+++ b/src/Opserver.Web/Opserver.Web.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
     <ProjectReference Include="..\Opserver.Core\Opserver.Core.csproj" />
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" PrivateAssets="all" />
     <PackageReference Include="BuildWebCompiler" Condition="'$(OS)' == 'Windows_NT'" Version="1.12.405" PrivateAssets="all" />

--- a/src/Opserver.Web/Opserver.Web.csproj
+++ b/src/Opserver.Web/Opserver.Web.csproj
@@ -2,29 +2,29 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>Opserver</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
     <ProjectReference Include="..\Opserver.Core\Opserver.Core.csproj" />
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" PrivateAssets="all" />
     <PackageReference Include="BuildWebCompiler" Condition="'$(OS)' == 'Windows_NT'" Version="1.12.405" PrivateAssets="all" />
-    <PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.2.22" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.35.0" />
-    <PackageReference Include="Serilog" Version="4.1.0" />
+    <PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.5.4" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.3.0" />
+    <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Enrichers.Sensitive" Version="1.7.3" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.4" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
-    <PackageReference Include="StackExchange.Exceptional.AspNetCore" Version="2.2.32" />
-    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="6.0.0" />
+    <PackageReference Include="StackExchange.Exceptional.AspNetCore" Version="3.0.1" />
+    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="9.0.0" />
     <Reference Include="System.Management" />
   </ItemGroup>
   <ItemGroup>
@@ -35,5 +35,9 @@
     <None Include="Config\Readme.txt" />
     <None Include="Config\*.example.json" />
     <None Include="compilerconfig.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.7.112" />
   </ItemGroup>
 </Project>

--- a/src/Opserver.Web/Startup.cs
+++ b/src/Opserver.Web/Startup.cs
@@ -166,7 +166,7 @@ namespace Opserver
                         foreach (var knownNetwork in knownNetworks)
                         {
                             var ipNet = IPNet.Parse(knownNetwork);
-                            options.KnownNetworks.Add(new IPNetwork(ipNet.IPAddress, ipNet.CIDR));
+                            options.KnownNetworks.Add(new Microsoft.AspNetCore.HttpOverrides.IPNetwork(ipNet.IPAddress, ipNet.CIDR));
                         }
                     }
                 }

--- a/src/Opserver.Web/opserverSettings.json
+++ b/src/Opserver.Web/opserverSettings.json
@@ -7,7 +7,7 @@
   "Modules": {
     /* Configuration for the SQL Server dashboard */
     "Sql": {
-      //"defaultConnectionString": "Data Source=$ServerName$;Initial Catalog=master;Integrated Security=SSPI;",
+      //"defaultConnectionString": "Data Source=$ServerName$;Initial Catalog=master;Integrated Security=SSPI;TrustServerCertificate=True",
       //"refreshIntervalSeconds": 30,
       //"instances": [
       //  { "name": "localhost" }

--- a/src/Opserver.Web/opserverSettings.json
+++ b/src/Opserver.Web/opserverSettings.json
@@ -42,7 +42,7 @@
       //  {
       //    "name": "Local",
       //    "queryTimeoutMs": 2000,
-      //    "connectionString": "Server=.;Database=Local.Exceptions;Integrated Security=SSPI;"
+      //    "connectionString": "Server=.;Database=Local.Exceptions;Integrated Security=SSPI;TrustServerCertificate=True"
       //  }
       //],
       "stackTraceReplacements": [

--- a/tests/Opserver.Tests/Opserver.Tests.csproj
+++ b/tests/Opserver.Tests/Opserver.Tests.csproj
@@ -2,11 +2,19 @@
   <PropertyGroup>
     <RootNamespace>Opserver.Tests</RootNamespace>
     <AssemblyName>Opserver.Tests</AssemblyName>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/Opserver.Web/Opserver.Web.csproj" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.11" />
    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Update="xunit" Version="2.9.2" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/tests/Opserver.Tests/Opserver.Tests.csproj
+++ b/tests/Opserver.Tests/Opserver.Tests.csproj
@@ -8,10 +8,5 @@
     <ProjectReference Include="../../src/Opserver.Web/Opserver.Web.csproj" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.11" />
-   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Update="xunit" Version="2.9.2" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
 </Project>

--- a/tests/Opserver.Tests/Opserver.Tests.csproj
+++ b/tests/Opserver.Tests/Opserver.Tests.csproj
@@ -12,9 +12,6 @@
   <ItemGroup>
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Update="xunit" Version="2.9.2" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.8.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Update="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR upgrades OpServer to .NET 8 and all packages to the latest supported version.

This completely removes any reference to System.Data.SqlClient.

[Here](https://stackeng.octopus.app/app#/Spaces-1/projects/opserver/deployments/releases/2024.12.16.140-pr/deployments/Deployments-179509) is a successfull Octopus deploy to https://opserver.ascn-dev.int.gcp.stackoverflow.net/.

I've manually tested the Exceptions and SQL modules in OpServer and everything looks good.