### PR TITLE
feat(elastic): support https endpoint

### DIFF
--- a/src/Opserver.Core/Data/Elastic/ElasticCluster.KnownNodes.cs
+++ b/src/Opserver.Core/Data/Elastic/ElasticCluster.KnownNodes.cs
@@ -60,7 +60,15 @@ namespace Opserver.Data.Elastic
                     Host = hostAndPort;
                     Port = DefaultElasticPort;
                 }
-                Url = $"http://{Host}:{Port}/";
+
+                if (Port == 443)
+                {
+                    Url = $"https://{Host}/";
+                }
+                else
+                {
+                    Url = $"http://{Host}:{Port}/";
+                }
             }
 
             public override string ToString() => Host;


### PR DESCRIPTION
On many of our elastic clusters we have a HTTPS endpoint, so sending plain-text HTTP (even with the port 443) will not work. This should make it work for us.