### PR TITLE
fix(elastic): connection issues with https

### DIFF
--- a/src/Opserver.Core/Data/Elastic/ElasticCluster.KnownNodes.cs
+++ b/src/Opserver.Core/Data/Elastic/ElasticCluster.KnownNodes.cs
@@ -36,7 +36,6 @@ namespace Opserver.Data.Elastic
                     Url = uri.ToString();
                     Host = uri.Host;
                     Port = uri.Port;
-                    new OpserverConfigException($"Inside Uri.TryCreate: {Url}, {Host}, {Port}").Log();
                     return;
                 }
 

--- a/src/Opserver.Core/Data/Elastic/ElasticCluster.KnownNodes.cs
+++ b/src/Opserver.Core/Data/Elastic/ElasticCluster.KnownNodes.cs
@@ -31,7 +31,7 @@ namespace Opserver.Data.Elastic
             public ElasticNode(string hostAndPort, ElasticSettings.Cluster clusterSettings)
             {
                 ClusterSettings = clusterSettings;
-                if (Uri.TryCreate(hostAndPort, UriKind.Absolute, out var uri))
+                if (hostAndPort[^3..] != "443" && Uri.TryCreate(hostAndPort, UriKind.Absolute, out var uri))
                 {
                     Url = uri.ToString();
                     Host = uri.Host;

--- a/src/Opserver.Core/Data/Elastic/ElasticCluster.KnownNodes.cs
+++ b/src/Opserver.Core/Data/Elastic/ElasticCluster.KnownNodes.cs
@@ -36,6 +36,7 @@ namespace Opserver.Data.Elastic
                     Url = uri.ToString();
                     Host = uri.Host;
                     Port = uri.Port;
+                    new OpserverConfigException($"Inside Uri.TryCreate: {Url}, {Host}, {Port}").Log();
                     return;
                 }
 


### PR DESCRIPTION
The `Uri.TryCreate()` function didn't play nicely with the HTTPS endpoints, so I needed to make a change to the conditional around that. This is now deployed to `load-test` and [working](https://opserver.load-test.int.gcp.stackoverflow.net/elastic).