### PR TITLE
ASCN-556:  Removes nuget.config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /app
 
 # Global
-COPY ./*.sln ./nuget.config ./
+COPY ./*.sln ./
 # Apps
 COPY src/*/*.csproj ./
 RUN for file in $(ls *.csproj); do mkdir -p src/${file%.*}/ && mv $file src/${file%.*}/; done

--- a/nuget.config
+++ b/nuget.config
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <packageSources>
-    <clear />
-    <add key="MyGet: Stack Overflow" value="https://www.myget.org/F/stackoverflow/api/v3/index.json" />
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
+  <disabledPackageSources>
+    <add key="nuget.org" value="true" />
+  </disabledPackageSources>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <disabledPackageSources>
-    <add key="nuget.org" value="true" />
-  </disabledPackageSources>
-</configuration>


### PR DESCRIPTION
# Description

Removes nuget.config.  Formerly we had myget in there which we don't have anymore alongside nuget.  Rather than define feeds in nuget.config we can just let the default feeds do their magic.  On local this will mean nuget and cloudsmith and in CI it will mean nuget.  Since this is a fork of a public repo we don't need/want cloudsmith to be used in CI builds anyway.

# How to Test

1. Build/Restore the app.
2. Review actions/workflow runs.